### PR TITLE
Revert "sdm660-common: Correct cryptfshw name"

### DIFF
--- a/sdm660.mk
+++ b/sdm660.mk
@@ -277,7 +277,7 @@ PRODUCT_PACKAGES += \
 
 # HW crypto
 PRODUCT_PACKAGES += \
-    vendor.qti.hardware.cryptfshw@1.0-service-qti
+    vendor.qti.hardware.cryptfshw@1.0-service-ioctl-qti
 
 # IDC
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
This reverts commit 89152ef4454ceb41a4f5b41a96e485d7ce9f63b0.