### PR TITLE
ipacm: Fix WLAN tethering offload

### DIFF
--- a/data-ipa-cfg-mgr/ipacm/src/ipacm.rc
+++ b/data-ipa-cfg-mgr/ipacm/src/ipacm.rc
@@ -25,10 +25,13 @@
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# msm specific files that need to be created on /data
+on post-fs-data
+    mkdir /data/vendor/ipa 0770 radio radio
+    chmod 0770 /data/vendor/ipa
+
 service vendor.ipacm /system/vendor/bin/ipacm
-    class main
+    class late_start
     user radio
     group radio inet
-
-on post-fs
-    start vendor.ipacm
+    writepid /dev/cpuset/system-background/tasks

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -359,10 +359,6 @@ on post-fs-data
     mkdir /data/vendor/netmgr 0770 radio radio
     chmod 0770 /data/vendor/netmgr
 
-    #create ipacm log dir
-    mkdir /data/vendor/ipa 0770 radio radio
-    chmod 0770 /data/vendor/ipa
-
     #Create QTI dir for logs
     mkdir /data/vendor/dataqti 0770 radio radio
     chmod 0770 /data/vendor/dataqti
@@ -629,14 +625,6 @@ service vendor.port-bridge /system/vendor/bin/port-bridge
     disabled
     oneshot
     writepid /dev/cpuset/system-background/tasks
-
-service vendor.ipacm /system/vendor/bin/ipacm
-    class main
-    user radio
-    group radio inet
-    disabled
-    writepid /dev/cpuset/system-background/tasks
-
 
 service vendor.sensors /vendor/bin/sscrpcd sensorspd
     class early_hal

--- a/sepolicy/vendor/ipacm.te
+++ b/sepolicy/vendor/ipacm.te
@@ -1,0 +1,4 @@
+# Fix for WLAN tethering offload
+# SELinux : avc:  denied  { set } for property=wifi.active.interface pid=2918 uid=1010 gid=1010 scontext=u:r::s0 tcontext=u:object_r:default_prop:s0 tclass=property_service
+allow hal_wifi_default exported_wifi_prop:property_service set;
+

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -40,3 +40,7 @@ sys.post_boot.parsed                u:object_r:vendor_mpctl_prop:s0
 
 # Hall wakeup
 persist.service.folio_daemon        u:object_r:system_prop:s0
+
+# Fix for WLAN tethering offload
+# SELinux : avc:  denied  { set } for property=wifi.active.interface pid=2918 uid=1010 gid=1010 scontext=u:r::s0 tcontext=u:object_r:default_prop:s0 tclass=property_service
+wifi.active.interface               u:object_r:exported_wifi_prop:s0


### PR DESCRIPTION
Fix reboot after 120 seconds on WLAN tethering enable.
Fix "target device is connected but no internet" issue.

Move ipacm-related sections from rootdir/etc/init.qcom.rc to data-ipa-cfg-mgr/ipacm/src/ipacm.rc
Make ipacm.rc look like vendor/qcom/opensource/data-ipa-cfg-mgr/ipacm/src/ipacm.rc but add
writepid /dev/cpuset/system-background/tasks to the service definition.
This let ipacm start after data decryption (it got killed on data decrypt and not respawned,
because was disabled).
This fixes following errors:
04-01 14:35:57.525   591 17586 W libc    : Unable to set property "ctl.interface_start" to "android.hardware.tetheroffload.config@1.0::IOffloadConfig/default": error code: 0x20
04-01 14:35:57.526  2665  3190 I ServiceManagement: getService: Trying again for android.hardware.tetheroffload.config@1.0::IOffloadConfig/default...
04-01 14:35:57.526   591 17586 E hwservicemanager: Failed to set property for starting android.hardware.tetheroffload.config@1.0::IOffloadConfig/default

Set wifi.active.interface context to exported_wifi_prop and allow hal_wifi_default to set it.
I don't know why context definition was not embedded to the contexts file, but now it is.
This fixes following errors:
[163263.846522] selinux: avc:  denied  { set } for property=wifi.active.interface pid=2733 uid=1010 gid=1010 scontext=u:r:hal_wifi_default:s0 tcontext=u:object_r:default_prop:s0 tclass=property_service permissive=0

I don't sure, but problems with offload seem to happen only with encrypted /data/.