### PR TITLE
 sdm660-common: unlabel vendor.camera.aux.packageblacklist

### DIFF
--- a/sepolicy/private/property_contexts
+++ b/sepolicy/private/property_contexts
@@ -1,2 +1,1 @@
 sys.listeners.registered   u:object_r:vendor_tee_listener_prop:s0
-vendor.camera.aux.packageblacklist u:object_r:vendor_camera_prop:s0


### PR DESCRIPTION
This is already defined in https://github.com/Havoc-OS/android_device_havoc_sepolicy/blob/ten/common/dynamic/property_contexts#L2