### PR TITLE
sdm660-common: init: remove lct diag

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -365,11 +365,6 @@ on post-fs-data
     mkdir /data/vendor/connectivity 0771 radio radio
     chown radio radio /data/vendor/connectivity
 
-    # Create the directories used by LctDiagSendData
-    mkdir /data/vendor/lct_diag 0771 root root
-    chown root root /data/vendor/lct_diag
-    rm /data/vendor/lct_diag/client_*
-
     # Create directory used by audio subsystem
     mkdir /data/vendor/audio 0770 audio audio
 


### PR DESCRIPTION
We dont need you at all

05-28 19:19:49.428     0     0 I init    : Command 'rm /data/vendor/lct_diag/client_*' action=post-fs-data (/vendor/etc/init/hw/init.qcom.rc:371) took 0ms and failed: unlink() failed: No such file or directory

Signed-off-by: Manish4586 <manish.n.manish45@gmail.com>